### PR TITLE
Error handling for functions

### DIFF
--- a/local-dev-env-vars.json
+++ b/local-dev-env-vars.json
@@ -1,10 +1,13 @@
 {
   "ProcessFormFunction": {
     "PROCESS_FORM_BUCKET": "basic-ruby-process-form",
-    "AWS_REGION": "us-east-1"
+    "AWS_REGION": "us-east-1",
+    "URL_EXPIRATION": "3"
   },
   "ShowFormFunction": {
     "PROCESS_FORM_BUCKET": "basic-ruby-process-form",
-    "AWS_REGION": "us-east-1"
+    "AWS_REGION": "us-east-1",
+    "URL_EXPIRATION": "3",
+    "MAX_FILE_SIZE": "10"
   }
 }

--- a/user_form/confirm_upload.rb
+++ b/user_form/confirm_upload.rb
@@ -16,6 +16,12 @@ module UserForm
         headers: {'Content-Type': "text/html"},
         body: response
       }
+    rescue => e
+      {
+        statusCode: 200,
+        headers: {'Content-Type': "text/html"},
+        body: HtmlResponse.error_page(e.message)
+      }
     end
   end
 end

--- a/user_form/html_response.rb
+++ b/user_form/html_response.rb
@@ -1,24 +1,18 @@
+require "erb"
+
 module HtmlResponse
   def self.upload_form(presigned_post)
-    <<~HTML
+    template = <<~HTML
       <html>
       <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
       </head>
       <body>
       <h1>Upload a JPEG</h1>
-      <form action="#{presigned_post.url}" method="post" enctype="multipart/form-data">
-      <input type="hidden" name="key" value="#{presigned_post.fields["key"]}">
-      <input type="hidden" name="acl" value="#{presigned_post.fields["acl"]}">
-      <input type="hidden" name="success_action_redirect" value="#{presigned_post.fields["success_action_redirect"]}">
-      <input type="hidden" name="Content-Type" value="#{presigned_post.fields["Content-Type"]}">
-      <input type="hidden" name="x-amz-server-side-encryption" value="#{presigned_post.fields["x-amz-server-side-encryption"]}">
-      <input type="hidden" name="x-amz-credential" value="#{presigned_post.fields["x-amz-credential"]}">
-      <input type="hidden" name="x-amz-algorithm" value="#{presigned_post.fields["x-amz-algorithm"]}">
-      <input type="hidden" name="x-amz-date" value="#{presigned_post.fields["x-amz-date"]}">
-      <input type="hidden" name="Policy" value="#{presigned_post.fields["policy"]}">
-      <input type="hidden" name="x-amz-signature" value="#{presigned_post.fields["x-amz-signature"]}">
-      <input type="hidden" name="x-amz-security-token" value="#{presigned_post.fields["x-amz-security-token"]}">
+      <form action="<%= presigned_post.url %>" method="post" enctype="multipart/form-data">
+      <% presigned_post.fields.each do |k, v| %>
+      <input type="hidden" name="<%= k %>" value="<%= v %>">
+      <% end %>
       <label for="file">File:</label>
       <input type="file" id="file" name="file" accept="image/jpeg">
       <input type="submit" value="Submit">
@@ -26,6 +20,8 @@ module HtmlResponse
       </body>
       </html>
     HTML
+    view = ERB.new(template, trim_mode: "<>")
+    view.result_with_hash(presigned_post: presigned_post)
   end
 
   def self.successfully_processed_form(submission_id, download_url)

--- a/user_form/html_response.rb
+++ b/user_form/html_response.rb
@@ -37,4 +37,18 @@ module HtmlResponse
       </html>
     HTML
   end
+
+  def self.error_page(error_message)
+    <<~HTML
+      <html>
+      <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      </head>
+      <body>
+      <h1>Error Processing Request</h1>
+      <p>#{error_message}</p>
+      </body>
+      </html>
+    HTML
+  end
 end

--- a/user_form/show_form.rb
+++ b/user_form/show_form.rb
@@ -35,6 +35,12 @@ module UserForm
         headers: {"Content-Type": "text/html"},
         body: HtmlResponse.upload_form(form_options(event: event, context: context))
       }
+    rescue => e
+      {
+        statusCode: 200,
+        headers: {"Content-Type": "text/html"},
+        body: HtmlResponse.error_page(e.message)
+      }
     end
 
     def self.form_options(event:, context:)


### PR DESCRIPTION
This PR which is linked to issue #5 and #7  has
- [x] A refactoring of the show_form template to reduce duplication and allow it to support new hidden input fields without having to add code.
- [x] Error handling for the ShowFormFunction that renders an HTML page if there is an error processing the request the function receives
- [x] Error handling for the ConfirmUpload Function that renders an HTML page if there is an error process the request the function receives.