### PR TITLE
Create thumbnails when a user uploads an image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,5 @@ $RECYCLE.BIN/
 
 # AWS SAM Build
 .aws-sam/
+.bundle
+vendor/*

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -14,6 +14,7 @@ phases:
       - bundle install
       - bundle exec standardrb
       - bundle exec rspec
+      - echo $CODEBUILD_WEBHOOK_TRIGGER
   build:
     commands:
       - sam build

--- a/image_processing/create_thumbnails.rb
+++ b/image_processing/create_thumbnails.rb
@@ -1,0 +1,8 @@
+module ImageProcessing
+  class CreateThumbnails
+    def self.hanlder(event:, context:)
+      p event
+      p context
+    end
+  end
+end

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -2,7 +2,7 @@ version = 0.1
 [default]
 [default.deploy]
 [default.deploy.parameters]
-stack_name = "basic-ruby"
+stack_name = "basic-ruby-create-thumbnails"
 s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-125yxfjpi5k0i"
 s3_prefix = "basic-ruby"
 region = "us-east-1"

--- a/template.yml
+++ b/template.yml
@@ -92,6 +92,9 @@ Resources:
             BucketName: !Ref ThumbnailsBucket
   ProcessFormBucket:
     Type: AWS::S3::Bucket
+    LambdaConfiguration:
+      Event: s3::ObjectCreated:*
+      Function: !Ref ConvertImageFunction
   ThumbnailsBucket:
     Type: AWS::S3::Bucket
   ConvertImageFunctionCanReadProcessForm:

--- a/template.yml
+++ b/template.yml
@@ -92,12 +92,8 @@ Resources:
             BucketName: !Ref ThumbnailsBucket
   ProcessFormBucket:
     Type: AWS::S3::Bucket
-    Properties:
-      BucketName: basic-ruby-process-form
   ThumbnailsBucket:
     Type: AWS::S3::Bucket
-    Properties:
-      BucketName: basic-ruby-thumbnails
   ConvertImageFunctionCanReadProcessForm:
     Type: AWS::IAM::Policy
     Properties:

--- a/template.yml
+++ b/template.yml
@@ -71,10 +71,49 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: AllAtOnce
+  ConvertImageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: image_processing
+      Handler: create_thumbnails.ImageProcessing::CreateThumbnails.handler
+      Runtime: ruby2.7
+      Events:
+        ImageUploaded:
+          Type: S3
+          Properties:
+            Bucket: !Ref ProcessFormBucket
+            Events: s3::ObjectCreated:*
+      Timeout: 600
+      Environment:
+        Variables:
+          OUTPUT_BUCKET: !Ref ThumbnailsBucket
+      Policies:
+        - S3FullAccessPolicy:
+            BucketName: !Ref ThumbnailsBucket
   ProcessFormBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: basic-ruby-process-form
+  ThumbnailsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: basic-ruby-thumbnails
+  ConvertImageFunctionCanReadProcessForm:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ConvertImageFunctionCanReadProcessForm
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - "s3::GetObject"
+            Resource:
+              - !Sub "${ProcessFormBucket.Arn}/*"
+      Roles:
+        - !Ref ConvertImageFunctionRole
+
+
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
This PR is related to #10. 

It creates the function to receive the S3 event when a user uploads an image
It creates an S3 bucket for that function to save files to after its done processing them.
Right now all the function does is print out the event and context it receives.

This PR also tests out ways to create a review version of the application. It does this by giving it a new stack name and  remove explicit names for the S3 buckets
